### PR TITLE
Add index page for the gh-pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,53 +1,49 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy to GitHub Pages
 
 on:
-  # Runs on main when a release is published
-  release:
-    types: [published]
-    branches: ["main"]
   push:
-    branches: ["main"]
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+    branches:
+      - main
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          override: true
+
       - name: Build the project
         run: cargo build --release --target wasm32-unknown-unknown
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
-      - name: Generate wasm-bindgen output
-        run: wasm-bindgen target/wasm32-unknown-unknown/release/random_shader_window.wasm --out-dir ./out --web
-      - name: Copy index.html to deploy directory
-        run: cp index.html ./out
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          # Upload entire repository
-          path: ./out
+          name: wasm-build
+          path: pkg
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: wasm-build
+          path: pkg
+
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./pkg

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,53 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on main when a release is published
+  release:
+    types: [published]
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build the project
+        run: cargo build --release --target wasm32-unknown-unknown
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli
+      - name: Generate wasm-bindgen output
+        run: wasm-bindgen target/wasm32-unknown-unknown/release/random_shader_window.wasm --out-dir ./out --web
+      - name: Copy index.html to deploy directory
+        run: cp index.html ./out
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: ./out
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ wgpu = { version = "24.0.1", features = ["webgl"] }
 bytemuck = "1.22.0"
 pollster = "0.4.0"
 wasm-bindgen-futures = "0.4.50"
+wasm-bindgen = "0.2.78"
+wasm-server-runner = "0.1.0"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Random Shader Window</title>
+</head>
+<body>
+    <script type="module">
+        import init from "./random_shader_window.js";
+        init();
+    </script>
+</body>
+</html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
+use wasm_bindgen::prelude::*;
 
 use random_shader_window::app::App;
 use winit::{event_loop::EventLoop, window::Window};
 
-fn main() {
+#[wasm_bindgen(start)]
+pub fn main() {
 	let event_loop = EventLoop::new().unwrap();
 
 	let window = Arc::new(


### PR DESCRIPTION
Add GitHub Actions workflow for deploying to GitHub Pages and update project for WebAssembly.

* **GitHub Actions Workflow**
  - Create `.github/workflows/deploy-gh-pages.yml` to deploy static content to GitHub Pages on push to `main` branch.
  - Add steps to check out the repository, set up Rust, build the project, install `wasm-bindgen-cli`, generate `wasm-bindgen` output, copy `index.html` to deploy directory, set up Pages, upload artifact, and deploy to GitHub Pages.

* **Project Configuration**
  - Modify `Cargo.toml` to add dependencies for `wasm-bindgen` and `wasm-server-runner`.

* **Main Function**
  - Modify `src/main.rs` to add `wasm_bindgen::prelude::*` to imports.
  - Add `#[wasm_bindgen(start)]` attribute to the `main` function.

* **Index Page**
  - Add `index.html` to load the WebAssembly module and generated JavaScript glue code.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cabrownlie/random-shader-window/pull/5?shareId=71264727-d332-4b9d-8d89-cd6d5de5bf82).